### PR TITLE
Fix minor script error

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -76,7 +76,7 @@ if [ "$existing_install_folder" != "" ]; then
 
 fi
 
-if [ $(which 7z) == "" ]; then
+if [ "$(which 7z)" == "" ]; then
     echo "7z command not found."
     echo "install 7z in wsl"
     echo "ubuntu: sudo apt install p7zip-full"


### PR DESCRIPTION
If `$(which 7z)` is not enclosed in quotes, plus `7z` was not installed,
then bash will report:
`install.sh: line 79: [: ==: unary operator expected`